### PR TITLE
compat wp5 + classic editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Adds a select2 selector for page template instead of basic dropdown menu
 
-
 ## Screenshots
 
 no more this :
@@ -17,7 +16,14 @@ now that :
 
 ```pts_is_edit_screen```, indeed to filter where it should be enqueued
 
+# Requirements
+
+* WP 5 and newer
+
 ## Changelog
+
+* October 2020
+* compat WP 5 (not Gutenberg because of accessibility issue)
 
 * March 2019
 * initial

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Julien Maury",
-      "email": "contact@julien-maury.com"
+      "email": "https://blog.julien-maury.com/en/contact"
     }
   ],
   "type": "wordpress-plugin"

--- a/page-template-select2.php
+++ b/page-template-select2.php
@@ -3,16 +3,14 @@
  * Plugin name: Page Template Select2
  * Description: adds a select2 selector for page template instead of basic dropdown menu
  * Author: Julien Maury
- * Version: 1.0
+ * Version: 2.0
  */
 
-
-/**
- * Dislaimer : for now it's meant only for pages not all template selectors in WordPress
- * TODO : Compat Gutenberg, i18n
- */
 defined( 'ABSPATH' )
 or die( '~Tryin' );
+
+define ( 'PTS_VERSION', '2.0' );
+define ( 'PTS_URL', plugin_dir_url( __FILE__ ) );
 
 add_action( 'admin_enqueue_scripts', '_pts_enqueue_scripts' );
 function _pts_enqueue_scripts( $hook_suffix ) {
@@ -21,25 +19,41 @@ function _pts_enqueue_scripts( $hook_suffix ) {
 		return false;
 	}
 
-	wp_register_style( 'select2css', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.min.css', false, '4.0.5', 'all' );
-	wp_register_script( 'select2', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.min.js', [ 'jquery' ], '4.0.5', true );
-	wp_enqueue_style( 'select2css' );
-	wp_enqueue_script( 'select2' );
+	if ( ! _pts_is_wp_version_greater_than() ) {
+		return false; // no support for wp version under 5 beta
+	}
 
-	$init = "(function($) { $('#page_template').select2(); })(jQuery);";
+	if ( ! _pts_gutenberg_is_enabled() ) {
+		_pts_maybe_grab_select2_scripts();
+		$init = "(function($) { $('#page_template').select2(); })(jQuery);";
+		wp_add_inline_script( 'select2', $init );
+	}
+}
 
-	wp_add_inline_script( 'select2', $init );
+function _pts_maybe_grab_select2_scripts() {
+	if ( ! wp_script_is( 'select2' ) ) {
+		wp_register_script( 'select2', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js', [ 'jquery' ], '4.0.13', true );
+		wp_enqueue_script( 'select2' );
+	}
 
+	if ( ! wp_style_is( 'select2' ) ) {
+		wp_register_style( 'select2', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css', false, '4.0.13', 'all' );
+		wp_enqueue_style( 'select2' );
+	}
 }
 
 function _pts_is_edit_screen( $slug ) {
 	return (bool) apply_filters( 'pts_is_edit_screen', in_array( $slug, [
 			'post.php',
 			'post-new.php'
-		], true ) && 'page' === get_post_type() && _pts_is_wp_version_smaller_than() );
+		], true ) );
 }
 
-function _pts_is_wp_version_smaller_than( $version = '5.0' ) {
+function _pts_is_wp_version_greater_than( $version = '5.0-beta' ) {
 	global $wp_version;
-	return version_compare( $wp_version, $version, '<' );
+	return version_compare( $wp_version, $version, '>' );
+}
+
+function _pts_gutenberg_is_enabled() {
+	return (bool) apply_filters( 'pts_is_gutenberg_enabled', ! class_exists( 'Classic_Editor' ) && ! class_exists( 'DisableGutenberg') );
 }


### PR DESCRIPTION
refactor + compatibility wp5 and newer
it's currently not possible to add select2 with external libraries such as react-select because of multiple accessibility issues